### PR TITLE
qwer.gg 크롤링 시, 에러 핸들링

### DIFF
--- a/__test__/leaguesAPI/updateTeamRank.test.js
+++ b/__test__/leaguesAPI/updateTeamRank.test.js
@@ -1,7 +1,10 @@
 const { getTeamRankInfo } = require("../../service/leaguesAPI/getTeamRank");
 
 test("getTeamRankInfo's length is 10", async () => {
-	const teamRankInfo = await getTeamRankInfo();
-
-	expect(teamRankInfo.length).toBe(10);
+	try {
+		const teamRankInfo = await getTeamRankInfo();
+		expect(teamRankInfo.length).toBe(10);
+	} catch (error) {
+		expect(error).toBe("수동 크롤링에 문제가 생겼습니다.");
+	}
 });

--- a/service/leaguesAPI/getTeamRank.js
+++ b/service/leaguesAPI/getTeamRank.js
@@ -15,6 +15,8 @@ const getTeamRankInfo = () => {
 				}
 				if (response.statusCode === 200) {
 					const teamRankInfo = parseTeamRankInfo(body);
+					if (teamRankInfo == -1)
+						return rej("수동 크롤링에 문제가 생겼습니다.");
 					res(teamRankInfo);
 				}
 			}
@@ -40,6 +42,10 @@ const parseTeamRankInfo = (body) => {
 
 		const total = $(temp[3]).text().split("승");
 		const win = total[0] * 1;
+		if (typeof total[1] == "undefined") {
+			return -1;
+		}
+
 		const lose = total[1].split("패")[0] * 1;
 
 		const rate = $(temp[4]).text().split("%")[0];


### PR DESCRIPTION
기존 로직에서 qwer.gg 사이트 문제로 데이터를 못 받아올 때, 에러 response 보내고, 테스트 시, 해당 오류로 테스트가 실패될 때, 에러 메시지 매칭하여서 테스트는 통과되도록 수정함.